### PR TITLE
Create emulator publisher.

### DIFF
--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -1,0 +1,185 @@
+package emulator
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/bartossh/Computantis/server"
+	"github.com/bartossh/Computantis/signerservice"
+	"github.com/valyala/fasthttp"
+)
+
+// Config contains configuration for the emulator Publisher and Subscriber.
+type Config struct {
+	TimeoutSeconds       int64  `yaml:"timeout_seconds"`
+	TickSeconds          int64  `yaml:"tick_seconds"`
+	Random               bool   `yaml:"random"`
+	SignerServiceAddress string `yaml:"signer_service_address"`
+	ReceiverAddress      string `yaml:"receiver_address"`
+}
+
+type publisher struct {
+	timeout  time.Duration
+	apiRoot  string
+	random   bool
+	position int
+}
+
+// RunPublisher runs publisher emulator that emulates data in a buffer.
+// Running emmulator is stopped by canceling context.
+func RunPublisher(ctx context.Context, config Config, data [][]byte) error {
+	if config.TimeoutSeconds < 1 || config.TimeoutSeconds > 20 {
+		return fmt.Errorf("wrong timeout_seconds parameter, expected value between 1 and 20 inclusive")
+	}
+
+	p := publisher{
+		timeout: time.Second * time.Duration(config.TimeoutSeconds),
+		apiRoot: config.SignerServiceAddress,
+		random:  config.Random,
+	}
+
+	var alive signerservice.AliveResponse
+	if err := p.makeGet(signerservice.Alive, &alive); err != nil {
+		return err
+	}
+	if alive.APIVersion != server.ApiVersion || alive.APIHeader != server.Header {
+		return fmt.Errorf(
+			"emulation not possible due to wrong headers and/or version, expected header %s, version %s, received header %s, version %s",
+			server.Header, server.ApiVersion, alive.APIHeader, alive.APIVersion)
+	}
+
+	if config.TickSeconds < 1 || config.TickSeconds > 60 {
+		return fmt.Errorf("wrong tick_seconds parameter, expected value between 1 and 60 inclusive")
+	}
+
+	t := time.NewTicker(time.Duration(config.TickSeconds) * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-t.C:
+			if err := p.emulate(ctx, config.ReceiverAddress, data); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (p *publisher) emulate(ctx context.Context, receiver string, data [][]byte) error {
+	switch p.random {
+	case true:
+		p.position = rand.Intn(len(data))
+	default:
+		p.position++
+	}
+
+	if p.position >= len(data) {
+		p.position = 0
+	}
+
+	t := time.NewTimer(time.Second * time.Duration(p.timeout))
+	defer t.Stop()
+	d := make(chan struct{}, 1)
+
+	var err error
+	go func() {
+		defer func() {
+			d <- struct{}{}
+		}()
+		req := signerservice.IssueTransactionRequest{
+			ReceiverAddress: receiver,
+			Subject:         "emulator-test",
+			Data:            data[p.position],
+		}
+		var resp signerservice.IssueTransactionResponse
+		err = p.makePost(signerservice.IssueTransaction, req, &resp)
+		if resp.Err != "" {
+			err = errors.New(resp.Err)
+			return
+		}
+		if !resp.Ok {
+			err = errors.New("unexpected error")
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil
+	case <-d:
+		return err
+	case <-t.C:
+		return errors.New("timeout")
+	}
+}
+
+func (p *publisher) makePost(path string, out, in any) error {
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+
+	req.SetRequestURI(path)
+	req.Header.SetMethod("POST")
+	req.Header.SetContentType("application/json")
+	raw, err := json.Marshal(out)
+	if err != nil {
+		return err
+	}
+	req.SetBody(raw)
+
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+
+	if err := fasthttp.DoTimeout(req, resp, p.timeout); err != nil {
+		return err
+	}
+
+	switch resp.StatusCode() {
+	case fasthttp.StatusOK, fasthttp.StatusCreated, fasthttp.StatusAccepted:
+	case fasthttp.StatusNoContent:
+		return nil
+	default:
+		return fmt.Errorf("expected status code %d but got %d", fasthttp.StatusOK, resp.StatusCode())
+	}
+
+	contentType := resp.Header.Peek("Content-Type")
+	if bytes.Index(contentType, []byte("application/json")) != 0 {
+		return fmt.Errorf("expected content type application/json but got %s", contentType)
+	}
+
+	return json.Unmarshal(resp.Body(), in)
+}
+
+func (p *publisher) makeGet(path string, out any) error {
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+
+	req.SetRequestURI(fmt.Sprintf("%s/%s", p.apiRoot, path))
+	req.Header.SetMethod("GET")
+
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+
+	if err := fasthttp.DoTimeout(req, resp, p.timeout); err != nil {
+		return err
+	}
+
+	switch resp.StatusCode() {
+	case fasthttp.StatusOK:
+	case fasthttp.StatusNoContent:
+		return nil
+	default:
+		return fmt.Errorf("expected status code %d but got %d", fasthttp.StatusOK, resp.StatusCode())
+	}
+
+	contentType := resp.Header.Peek("Content-Type")
+	if bytes.Index(contentType, []byte("application/json")) != 0 {
+		return fmt.Errorf("expected content type application/json but got %s", contentType)
+	}
+
+	return json.Unmarshal(resp.Body(), out)
+}

--- a/signerservice/signservice.go
+++ b/signerservice/signservice.go
@@ -98,12 +98,15 @@ func Run(ctx context.Context, cfg Config, log logger.Logger, timeout time.Durati
 	return err
 }
 
+// AliveResponse is containing server alive data such as ApiVersion and APIHeader.
+type AliveResponse server.AliveResponse
+
 func (a *app) alive(c *fiber.Ctx) error {
 	if err := a.client.ValidateApiVersion(); err != nil {
 		return errors.Join(fiber.ErrConflict, err)
 	}
 	return c.JSON(
-		server.AliveResponse{
+		AliveResponse{
 			Alive:      true,
 			APIVersion: server.ApiVersion,
 			APIHeader:  server.Header,


### PR DESCRIPTION
A basic emulator publisher allows using the client containing a wallet for emulating some data transaction.
Data are raw binary for simplicity.
No tests are present (yet). The emulator is needed for the demo and isn't part of the project (restricted time).
The emulator should run alongside the client wallet. The wallet allows signing data. 
Comunication is over HTTP (for now).
The setup uses a yaml file. YAML will be provided in the implementation using the emulator.

The next step is to add an emulator subscriber presenting data. (Simplistic, in the terminal client).