### PR TITLE
DNM: docker,make,config: enable build/bringup of emulator docker images

### DIFF
--- a/Dockerfile-emulators
+++ b/Dockerfile-emulators
@@ -1,0 +1,23 @@
+FROM golang:latest AS builder
+ARG APPLICATION
+WORKDIR /app
+COPY . .
+RUN go mod tidy
+RUN CGO_ENABLED=0 go build -a -installsuffix cgo -o cmd/${APPLICATION}/main -ldflags="-s -w" cmd/${APPLICATION}/main.go
+
+FROM alpine AS app
+ARG APPLICATION
+ARG DATAFILE
+ARG ROLE
+RUN apk --no-cache add ca-certificates
+WORKDIR /app
+COPY --from=builder /app/cmd/${APPLICATION}/main ./
+COPY --from=builder /app/setup_example.yaml ./
+COPY --from=builder /app/${DATAFILE} ./
+ENV DATAFILE=${DATAFILE}
+ENV ROLE=${ROLE}
+
+# ENTRYPOINT in shell form to allow ENV variable expansion.  This is needed to determine
+# what role the emulator will play (publisher, or subscriber), and as a result, which
+# data file it needs.
+ENTRYPOINT ./main -c setup_example.yaml -d ${DATAFILE} ${ROLE}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -88,6 +88,42 @@ services:
     depends_on:
       validator-node:
         condition: service_started
+
+  # demo only
+  subscriber-node:
+    container_name: subscriber-node
+    build:
+      dockerfile: Dockerfile-emulators
+      args:
+        - "APPLICATION=emulator"
+        - "ROLE=subscriber"
+        - "DATAFILE=minmax.json"
+    profiles: ["demo"]
+    restart: unless-stopped
+    ports:
+      - "8060:8060"
+    networks:
+      - computantis_network
+    depends_on:
+      validator-node:
+        condition: service_started
+
+  # demo only
+  publisher-node:
+    container_name: publisher-node
+    build:
+      dockerfile: Dockerfile-emulators
+      args:
+        - "APPLICATION=emulator"
+        - "ROLE=publisher"
+        - "DATAFILE=data.json"
+    profiles: ["demo"]
+    restart: unless-stopped
+    networks:
+      - computantis_network
+    depends_on:
+      subscriber-node:
+        condition: service_started
  
   node-exporter:
     image: prom/node-exporter:latest

--- a/makefile
+++ b/makefile
@@ -50,17 +50,37 @@ start: build-local run-all
 docker-dependencies:
 	docker compose up -f docker-compose.dependencies.yaml -d
 
-docker-all:
+# docker-up|down|logs all take into account the environment variable COMPOSE_PROFILES
+# per https://docs.docker.com/compose/profiles/
+# To run a complete demo with publisher and subscriber nodes, use:
+#   COMPOSE_PROFILES=demo make docker-up|down|logs
+# To run core services only, use:
+#   make docker-up|down|logs
+docker-up:
 	docker compose up -d
 
-docker-central-build:
-	docker compose up -d --no-deps --build central-node
+docker-down:
+	docker compose down
 
-docker-validator-build:
-	docker compose up -d --no-deps --build validator-node
+docker-logs:
+	docker compose logs -f
 
-docker-client-build:
-	docker compose up -d --no-deps --build client-node
+docker-build-all: docker-build-central docker-build-validator docker-build-client docker-build-subscriber docker-build-publisher
+
+docker-build-central:
+	docker compose build central-node
+
+docker-build-validator:
+	docker compose build validator-node
+
+docker-build-client:
+	docker compose build client-node
+
+docker-build-subscriber:
+	docker compose build subscriber-node
+
+docker-build-publisher:
+	docker compose build publisher-node
 
 scan:
 	govulncheck ./...

--- a/setup_example.yaml
+++ b/setup_example.yaml
@@ -27,7 +27,7 @@ emulator:
   timeout_seconds: 20
   tick_seconds: 1
   random: false
-  client_url: "http://client-node:8020"
+  client_url: "http://client-node:8000"
   port: "8060"
   public_url: "http://subscriber-node:8060" # If running emulators locally, best to set it up as your local network machine IP.
 zinc_logger:

--- a/setup_example.yaml
+++ b/setup_example.yaml
@@ -27,9 +27,9 @@ emulator:
   timeout_seconds: 20
   tick_seconds: 1
   random: false
-  client_url: "http://localhost:8020"
+  client_url: "http://client-node:8020"
   port: "8060"
-  public_url: "http://192.168.0.143:8060" # Best to set it up as your local network machine IP. 
+  public_url: "http://subscriber-node:8060" # If running emulators locally, best to set it up as your local network machine IP.
 zinc_logger:
   address: http://zincsearch:4080 
   index: central


### PR DESCRIPTION
- Enable building emulators (subscriber-node, publisher-node) as docker images.
- Make use of compose profiles to start core services, or a full demo environment with subscriber and publisher nodes.
- Separate docker build and run concerns in makefile.  Done to prevent publisher/subscriber nodes from entering start/stop loop due to runtime service dependencies.