### PR TITLE
199 verify signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,16 @@ Install govulncheck to perform vulnerability scanning  `go install golang.org/x/
 
 ### Development
 
+C version of client-node isn't cross platform.
+This software is developed to be used with Linux and is tested for x86_64 Linux 5.15.0-76-generic kernel version.
+This software was tested with `gcc` compiler and while it might work with `clan`, `g++` or `c++` it is highly recommended to not use them.
+The `gcc` compiler used for the test and development is `gcc version 9.4.0`.
+
+1. Install dependencies:
+
+- Install build essentials.
+- Install openssl library.
+
 #### Tests
 
 In `c/` folder contains protocol implementation for client node written in C. 

--- a/c/client-node/address/address.c
+++ b/c/client-node/address/address.c
@@ -1,3 +1,12 @@
+///
+/// Copyright (C) 2023 by Computantis
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without l> imitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+/// 
+/// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+///
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>

--- a/c/client-node/address/address.h
+++ b/c/client-node/address/address.h
@@ -1,3 +1,12 @@
+///
+/// Copyright (C) 2023 by Computantis
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without l> imitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+/// 
+/// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+///
 #ifndef ADDRESS_H
 #define ADDRESS_H
 #define PUBLIC_KEY_LEN 32

--- a/c/client-node/address/base58.c
+++ b/c/client-node/address/base58.c
@@ -1,21 +1,12 @@
-/// Current version of the file is pednantic modification of the below code:
-/// https://github.com/luke-jr/libbase58/blob/master/base58.c
-/// This part of the software is distributed under MIT LICENSE according to the Author license.
-/*
- * Copyright 2023 Computantis
- *
- * Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
- * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- */
-
+///
+/// Copyright (C) 2023 by Computantis
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without l> imitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+/// 
+/// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+///
 #ifndef WIN32
 #include <arpa/inet.h>
 #else

--- a/c/client-node/address/libbase58.h
+++ b/c/client-node/address/libbase58.h
@@ -1,21 +1,12 @@
-/// Current version of the file is pednantic modification of the below code:
-/// https://github.com/luke-jr/libbase58/blob/master/libbase58.h
-/// This part of the software is distributed under MIT LICENSE according to the Author license.
-/*
- * Copyright 2023 Computantis
- *
- * Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
- * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
- * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- */
-
+///
+/// Copyright (C) 2023 by Computantis
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without l> imitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+/// 
+/// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+///
 #ifndef LIBBASE58_H
 #define LIBBASE58_H
 

--- a/c/client-node/client.h
+++ b/c/client-node/client.h
@@ -1,3 +1,12 @@
+///
+/// Copyright (C) 2023 by Computantis
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without l> imitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+/// 
+/// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+///
 #ifndef CLIENT_H
 #define CLIENT_H
 

--- a/c/client-node/makefile
+++ b/c/client-node/makefile
@@ -20,6 +20,7 @@ ASANFLAGS += -fno-omit-frame-pointer
 TEST_PACKAGES = test-framework/unity.c
 PACKAGES = ./signer/*.c
 PACKAGES += ./address/*.c
+PACKAGES += ./signature/*.c
 PACKAGES += ./*.c
 
 .PHONY: test

--- a/c/client-node/signature/signature.c
+++ b/c/client-node/signature/signature.c
@@ -1,0 +1,130 @@
+///
+/// Copyright (C) 2023 by Computantis
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without l> imitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+/// 
+/// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+///
+#include <stdlib.h>
+#include <string.h>
+#include <openssl/evp.h>
+#include <openssl/sha.h>
+#include "signature.h"
+
+void Signature_free(Signature *sig)
+{
+    if (sig == NULL)
+    {
+        return;
+    }
+    if (sig->signature_buffer != NULL)
+    {
+        OPENSSL_free(sig->signature_buffer);
+        sig->signature_buffer = NULL;
+    }
+    if (sig->digest_buffer != NULL)
+    {
+        free(sig->digest_buffer);
+        sig->digest_buffer = NULL;
+    }
+    sig->signature_len = 0;
+    sig->digest_len = 0;
+    return;
+}
+
+static bool digest_cmp(unsigned char *a, unsigned char* b)
+{
+    for (size_t i = 0; i < SHA256_DIGEST_LENGTH; i++)
+    {
+        if (a[i] != b[i])
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool Signature_verify(Signature *sig, EVP_PKEY *pkey, unsigned char *msg, size_t msg_len)
+{
+
+    if (sig == NULL)
+    {
+        printf("Signerature is NULL\n");
+        exit(1);
+    }
+
+    if (sig->signature_buffer == NULL || sig->signature_len == 0)
+    {
+        printf("Signature inner buffer is empty \n");
+        exit(1);
+    }
+    if (sig->digest_buffer == NULL || sig->digest_len == 0)
+    {
+        printf("Digest inner buffer is empty \n");
+        exit(1);
+    }
+
+    if (msg_len <= 0)
+    {
+        msg_len = strlen((char*)msg);
+    }
+    if (msg_len == 0)
+    {
+        printf("Message of zero length cannot be signed\n");
+        exit(1);
+    }
+
+    size_t digest_len = SHA256_DIGEST_LENGTH; 
+    unsigned char *digest = malloc(sizeof(unsigned char) * digest_len);
+    if (digest == NULL)
+    {
+        printf("Allocating memory of size [ %li ] bytes for digest buffer failed\n", digest_len);
+        exit(1);
+    }
+
+    unsigned char *flag = SHA256(msg, msg_len, digest);
+    if (flag == NULL)
+    {
+        printf("Hashing message failed\n");
+        exit(1);
+    }
+
+    bool ok = digest_cmp(digest, sig->digest_buffer);
+    if (!ok)
+    {
+        free(digest);
+        digest = NULL;
+        return false;
+    }
+    free(digest);
+    digest = NULL;
+
+    EVP_MD_CTX *mdctx = EVP_MD_CTX_create();
+    if (mdctx == NULL)
+    {
+        printf("Context allocation failed\n");
+        exit(1);
+    }
+    if (pkey == NULL)
+    {
+        printf("Public key is NULL\n");
+        exit(1);
+    }
+
+    int success = EVP_DigestVerifyInit(mdctx, NULL, NULL, NULL, pkey);
+    if (success != 1)
+    {
+        printf("Public key context allocation failed.\n");
+        exit(1);
+    }
+
+    success = EVP_DigestVerify(mdctx, sig->signature_buffer, sig->signature_len, sig->digest_buffer, sig->digest_len);
+
+    EVP_MD_CTX_free(mdctx);
+
+    return success == 1;
+}
+

--- a/c/client-node/signature/signature.h
+++ b/c/client-node/signature/signature.h
@@ -7,10 +7,34 @@
 ///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ///
-#include "client.h"
-#include <stdbool.h>
+#ifndef SIGNATURE_H
+#define SIGNATURE_H
+#define KEY_LEN 32
 
-bool check_client(const int number)
-{
-    return number > 0;
-}
+#include <openssl/evp.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+/// 
+/// Signature is an entity holding the signature and digest of the message.
+///
+typedef struct {
+    unsigned char *digest_buffer;
+    unsigned char *signature_buffer;
+    size_t digest_len;
+    size_t signature_len;
+} Signature;
+
+///
+/// Signature_free frees the signature.
+///
+void Signature_free(Signature *sig);
+
+///
+/// Signature_verify verifies the signature for the given message.
+/// It produces digest from given message
+/// and then verifies signature for that digest.
+///
+bool Signature_verify(Signature *sig, EVP_PKEY *pkey, unsigned char *msg, size_t msg_len);
+
+#endif

--- a/c/client-node/signer/signer.h
+++ b/c/client-node/signer/signer.h
@@ -1,10 +1,20 @@
+///
+/// Copyright (C) 2023 by Computantis
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without l> imitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+/// 
+/// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+///
 #ifndef SIGNER_H
 #define SIGNER_H
 #define KEY_LEN 32
 
-#include <openssl/evp.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <openssl/evp.h>
+#include "../signature/signature.h"
 
 ///
 /// Signer type allows to perform cryptographic operations on the given bytes buffer.
@@ -22,16 +32,6 @@ typedef struct {
     unsigned char *buffer;
     size_t len;
 } RawCryptoKey;
-
-/// 
-/// Signature is an entity holding the signature and digest of the message that was a subject of signing.
-///
-typedef struct {
-    unsigned char *digest_buffer;
-    unsigned char *signature_buffer;
-    size_t digest_len;
-    size_t signature_len;
-} Signature;
 
 ///
 /// Signer_new creates a new Signer and returns a copy of that entity.
@@ -65,6 +65,19 @@ RawCryptoKey Signer_get_private_key(Signer *s);
 ///
 RawCryptoKey Signer_get_public_key(Signer *s);
 
+
+/// 
+/// RawCryptoKey_get_evp_public_key returns pointer to EVP_PKEY
+/// from openssl.evp.h library that is a public key.
+///
+EVP_PKEY *RawCryptoKey_get_evp_public_key(RawCryptoKey *r);
+
+/// 
+/// RawCryptoKey_get_evp_private_key returns pointer to EVP_PKEY
+/// from openssl.evp.h library that is a private key.
+///
+EVP_PKEY *RawCryptoKey_get_evp_private_key(RawCryptoKey *r);
+
 ///
 /// RawCryptoKey_free frees the RawCryptoKey;
 ///
@@ -83,10 +96,5 @@ void RawCryptoKey_free(RawCryptoKey *r);
 /// For the ed25519 algorithm digest is 32 bytes long and signature is 64 bytes long.
 ///
 Signature Signer_sign(Signer *s, unsigned char *msg, size_t len);
-
-///
-/// Signature_free frees the signature.
-///
-void Signature_free(Signature *sig);
 
 #endif

--- a/c/client-node/test_client.c
+++ b/c/client-node/test_client.c
@@ -248,7 +248,7 @@ static void test_signer_verify_signature_failure_wrong_pub_key(void)
     TEST_ASSERT_NULL(wrong_s.evpkey);
 }
 
-static void test_signer_verify_signature_success_corrupted_msg(void)
+static void test_signer_verify_signature_failure_corrupted_msg(void)
 {
     // Prepare
     Signer s = Signer_new();
@@ -287,7 +287,7 @@ static void test_signer_verify_signature_success_corrupted_msg(void)
     TEST_ASSERT_NULL(s.evpkey);
 }
 
-static void test_signer_verify_signature_success_corrupted_digest(void)
+static void test_signer_verify_signature_failure_corrupted_digest(void)
 {
     // Prepare
     Signer s = Signer_new();
@@ -340,8 +340,8 @@ int main(void)
     RUN_TEST(test_signer_sign);
     RUN_TEST(test_signer_verify_signature_success);
     RUN_TEST(test_signer_verify_signature_failure_wrong_pub_key);
-    RUN_TEST(test_signer_verify_signature_success_corrupted_msg);
-    RUN_TEST(test_signer_verify_signature_success_corrupted_digest);
+    RUN_TEST(test_signer_verify_signature_failure_corrupted_msg);
+    RUN_TEST(test_signer_verify_signature_failure_corrupted_digest);
 
     return UnityEnd();
 }

--- a/header.md
+++ b/header.md
@@ -287,6 +287,16 @@ Install govulncheck to perform vulnerability scanning  `go install golang.org/x/
 
 ### Development
 
+C version of client-node isn't cross platform.
+This software is developed to be used with Linux and is tested for x86_64 Linux 5.15.0-76-generic kernel version.
+This software was tested with `gcc` compiler and while it might work with `clan`, `g++` or `c++` it is highly recommended to not use them.
+The `gcc` compiler used for the test and development is `gcc version 9.4.0`.
+
+1. Install dependencies:
+
+- Install build essentials.
+- Install openssl library.
+
 #### Tests
 
 In `c/` folder contains protocol implementation for client node written in C. 


### PR DESCRIPTION
- Signature can verify itself against the public key.
- Signature precalculates digest itself again to check if the message is not corrupted before validating the signature.
- I've introduced new functions to get the public key and private key in the form of EVP_PKEY (from openssl/evp.h) for verification. This will allow for future development when transactions will have a bytes buffer of raw public key encoded to base58. So we know that the issuer with the given address is the owner of a signed message.

Please test on your machine with `make memcheck` <- to verify against memory leaks. 
Test cleanup with `make clean`.

