### PR TITLE
Alter transaction empulation  print. Remove spinner use info.

### DIFF
--- a/emulator/publisher.go
+++ b/emulator/publisher.go
@@ -65,19 +65,15 @@ func RunPublisher(ctx context.Context, cancel context.CancelFunc, config Config,
 
 	t := time.NewTicker(time.Duration(config.TickSeconds) * time.Second)
 	defer t.Stop()
-	spinner, _ := pterm.DefaultSpinner.Start("Emulating transaction publisher...")
-	defer spinner.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-t.C:
-			spinner, _ = pterm.DefaultSpinner.Start(fmt.Sprintf("Making [ %d ] transaction emulation.\n", p.position+1))
 			if err := p.emulate(ctx, addr.Address, measurtements); err != nil {
-				spinner.Warning()
 				return err
 			}
-			spinner.Success()
+			pterm.Info.Printf("Emulated and published [ %d ] transaction from the given dataset.\n", p.position+1)
 		}
 	}
 }
@@ -123,8 +119,6 @@ func (p *publisher) emulate(ctx context.Context, receiver string, measurements [
 		if !resp.Ok {
 			err = errors.New("unexpected error")
 		}
-
-		pterm.Info.Printf("Emulated measuremnt: %#v.", measurements[p.position])
 	}()
 
 	select {

--- a/emulator/subscriber.go
+++ b/emulator/subscriber.go
@@ -284,7 +284,7 @@ func (sub *subscriber) validateData(data []byte) error {
 func (sub *subscriber) appendToBuffer(status string, trx transaction.Transaction) {
 	var m Measurement
 	if err := json.Unmarshal(trx.Data, &m); err != nil {
-		pterm.Error.Printf("Failed to marshal mesuremet due to: %s", err)
+		pterm.Error.Printf("Failed to marshal measurement due to: %s", err)
 		return
 	}
 	sub.buffer = append(sub.buffer, Message{


### PR DESCRIPTION
Remove the spinner in favour of info print. There is no time for the spinner to spin (emulation happens in one second). It is better to use info print.