### PR TITLE
Create config reader that reads client node configuration from the file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,28 @@ The `gcc` compiler used for the test and development is `gcc version 9.4.0`.
 1. Install dependencies:
 
 - Install build essentials.
+
+```sh
+sudo apt install build-essential
+```
+
 - Install openssl library.
+
+```sh
+sudo apt install openssl
+```
+
+- Install autoconf
+
+```sh
+sudo apt-get install autoconf
+```
+
+- Install libtool
+
+```sh
+sudo apt install libtool
+```
 
 #### Tests
 

--- a/c/client-node/address/address.c
+++ b/c/client-node/address/address.c
@@ -18,7 +18,7 @@ char *encode_address_from_raw(unsigned char *raw, size_t len)
 {
     if (len != PUBLIC_KEY_LEN)
     {
-        printf("public private key length is not valid, expected: [ %i ], got: [ %zi ]\n", PUBLIC_KEY_LEN, len);
+        printf("Public private key length is not valid, expected: [ %i ], got: [ %zi ]\n", PUBLIC_KEY_LEN, len);
         exit(1);
     }
 
@@ -26,14 +26,14 @@ char *encode_address_from_raw(unsigned char *raw, size_t len)
     char *b58 = malloc(sizeof(char)*b58_len);
     if (b58 == NULL)
     {
-        printf("failed to allocate [ %li ] bytes\n", b58_len);
+        printf("Failed to allocate [ %li ] bytes\n", b58_len);
         exit(1);
     }
     
     bool ok = b58enc(b58, &b58_len, (void *)raw, len);
     if (!ok)
     {
-        printf("base58 encoding faild\n");
+        printf("Base58 encoding faild\n");
         exit(1);
     }
 
@@ -46,14 +46,14 @@ int decode_address_to_raw(char *str, unsigned char **raw)
     *raw = malloc(sizeof(unsigned char)*len);
     if (*raw == NULL)
     {
-        printf("failed to allocate [ %li ] bytes\n", len);
+        printf("Failed to allocate [ %li ] bytes\n", len);
         exit(1);
     }
     
     bool ok = b58tobin(*raw, &len, str, strlen(str));
     if (!ok)
     {
-        printf("base58 decoding faild\n");
+        printf("Base58 decoding faild\n");
         exit(1);
     }
 

--- a/c/client-node/config/config.c
+++ b/c/client-node/config/config.c
@@ -1,0 +1,130 @@
+///
+/// Copyright (C) 2023 by Computantis
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without l> imitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+/// 
+/// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+///
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <ctype.h> 
+#include "config.h"
+
+#define MAX_LINE_LENGTH 32768
+#define MAX_TOKEN_NAME_LENGTH 8192
+#define MAX_TOKEN_VALUE_LENGTH 24576
+
+static char *trim_white_space(char *str)
+{
+    char *end;
+
+    while(isspace((unsigned char)*str))
+    {
+        str++;
+    }
+
+    if(*str == 0)
+    {
+        return str;
+    }
+    
+    end = str + strlen(str) - 1;
+    while(end > str && isspace((unsigned char)*end))
+    {
+        end--;
+    }
+
+    end[1] = '\0';
+
+    return str;
+}
+
+static bool assign_to_config(Config *cfg, char *name, char *token)
+{
+    char *name_trimed = trim_white_space(name);
+    char *token_trimed = trim_white_space(token);
+    size_t len = strlen(token_trimed);
+    
+    if (len > MAX_TOKEN_VALUE_LENGTH)
+    {
+        return false;
+    }
+
+    if (strcmp("port", name_trimed) == 0)
+    {
+        cfg->port = atoi(token_trimed);
+        return true;
+    }
+    
+    if (strcmp("node_public_url", name_trimed) == 0)
+    {
+        strncpy(cfg->node_public_url, token_trimed, len);
+        return true;
+    }
+
+    if (strcmp("validator_url", name_trimed) == 0)
+    {
+        strncpy(cfg->validator_url, token_trimed, len);
+        return true;
+    }
+
+    if (strcmp("pem_file", name_trimed) == 0)
+    {
+        strncpy(cfg->pem_file, token_trimed, len);
+        return true;
+    }
+
+    return false;
+}
+
+Config Config_new_from_file(char *file_path)
+{
+    FILE    *textfile;
+    char    line[MAX_LINE_LENGTH];
+    Config cfg;
+     
+    textfile = fopen(file_path, "r");
+    if(textfile == NULL)
+    {
+        printf("Cannot open config file: %s\n", file_path);
+        exit(1);
+    }
+     
+    while(fgets(line, MAX_LINE_LENGTH, textfile)){
+        char *line_trimed = trim_white_space(line);
+        char *token = strtok(line_trimed, ":");
+        size_t position = 0;
+        char name[MAX_TOKEN_NAME_LENGTH];
+        while(token != NULL && position < 2)
+        {
+            if (position == 0)
+            {
+                size_t len = strlen(token);
+                if (len > MAX_TOKEN_NAME_LENGTH)
+                {
+                    printf("Max key name size exceeded, allowed %i, have %li\n", MAX_TOKEN_NAME_LENGTH, len);
+                    exit(1);
+                }
+                strncpy(name, token, len);
+                name[len] = '\0';
+            } else {
+                bool ok = assign_to_config(&cfg, name, token);
+                if (!ok)
+                {
+                    printf("Given key name %s with value %s assign to congig failed\n", name, token);
+                    exit(1);
+                }
+            }
+            token = strtok(NULL, "");
+            position++;
+        }
+    }
+     
+    fclose(textfile);
+
+    return  cfg;
+}

--- a/c/client-node/config/config.h
+++ b/c/client-node/config/config.h
@@ -1,0 +1,30 @@
+///
+/// Copyright (C) 2023 by Computantis
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without l> imitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+/// 
+/// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+///
+
+#ifndef CONFIG_H
+#define CONFIG_H
+#define MAX_STRING 8192
+
+/// 
+/// Config represents configuration required for the client node to run.
+///
+typedef struct {
+    int port;
+    char node_public_url[MAX_STRING];
+    char validator_url[MAX_STRING];
+    char pem_file[MAX_STRING];
+} Config;
+
+/// 
+/// Config_new_from_file reads Config from provided file path.
+///
+Config Config_new_from_file(char *file_path);
+
+#endif

--- a/c/client-node/default_config.txt
+++ b/c/client-node/default_config.txt
@@ -1,0 +1,4 @@
+port : 8080
+node_public_url : http://client-node:8080
+validator_url : http://validator-node:8000
+pem_file : ed25519.pem

--- a/c/client-node/makefile
+++ b/c/client-node/makefile
@@ -21,6 +21,7 @@ TEST_PACKAGES = test-framework/unity.c
 PACKAGES = ./signer/*.c
 PACKAGES += ./address/*.c
 PACKAGES += ./signature/*.c
+PACKAGES += ./config/*.c
 PACKAGES += ./*.c
 
 .PHONY: test

--- a/c/client-node/test_client.c
+++ b/c/client-node/test_client.c
@@ -16,6 +16,7 @@
 #include "./signer/signer.h"
 #include "./address/address.h"
 #include "./signature/signature.h"
+#include "./config/config.h"
 
 
 void setUp(void)
@@ -56,7 +57,7 @@ static void test_signer_public_key()
     TEST_ASSERT_NULL(raw_key.buffer);
     TEST_ASSERT_EQUAL_UINT(0, raw_key.len);
     
-    // Prepare clenup
+    // Prepare cleanup
     Signer_free(&s);
     TEST_ASSERT_NULL(s.evpkey);
 }
@@ -97,7 +98,7 @@ static void test_signer_save_read_pem(void)
     TEST_ASSERT_TRUE(ok);
     TEST_ASSERT_NOT_NULL(s1.evpkey);
 
-    // Prepare clenup
+    // Prepare cleanup
     Signer_free(&s0);
     TEST_ASSERT_NULL(s0.evpkey);
     Signer_free(&s1);
@@ -158,7 +159,7 @@ static void test_signer_sign(void)
 
     Signature_free(&sig);
 
-    // Prepare clenup
+    // Prepare cleanup
     Signer_free(&s);
     TEST_ASSERT_NULL(s.evpkey);
 }
@@ -190,7 +191,7 @@ static void test_signer_verify_signature_success(void)
     Signature_free(&sig);
     EVP_PKEY_free(pkey);
 
-    // Prepare clenup
+    // Prepare cleanup
     RawCryptoKey_free(&raw_pub_key);
     TEST_ASSERT_NULL(raw_pub_key.buffer);
     TEST_ASSERT_EQUAL_UINT(0, raw_pub_key.len);
@@ -231,7 +232,7 @@ static void test_signer_verify_signature_failure_wrong_pub_key(void)
     Signature_free(&sig);
     EVP_PKEY_free(pkey);
 
-    // Prepare clenup
+    // Prepare cleanup
     RawCryptoKey_free(&raw_pub_key);
     TEST_ASSERT_NULL(raw_pub_key.buffer);
     TEST_ASSERT_EQUAL_UINT(0, raw_pub_key.len);
@@ -279,7 +280,7 @@ static void test_signer_verify_signature_failure_corrupted_msg(void)
     Signature_free(&sig);
     EVP_PKEY_free(pkey);
 
-    // Prepare clenup
+    // Prepare cleanup
     RawCryptoKey_free(&raw_pub_key);
     TEST_ASSERT_NULL(raw_pub_key.buffer);
     TEST_ASSERT_EQUAL_UINT(0, raw_pub_key.len);
@@ -319,12 +320,24 @@ static void test_signer_verify_signature_failure_corrupted_digest(void)
     Signature_free(&sig);
     EVP_PKEY_free(pkey);
 
-    // Prepare clenup
+    // Prepare cleanup
     RawCryptoKey_free(&raw_pub_key);
     TEST_ASSERT_NULL(raw_pub_key.buffer);
     TEST_ASSERT_EQUAL_UINT(0, raw_pub_key.len);
     Signer_free(&s);
     TEST_ASSERT_NULL(s.evpkey);
+}
+
+static void test_read_config()
+{
+    Config cfg = Config_new_from_file("./default_config.txt");
+    TEST_ASSERT_EQUAL_INT(8080, cfg.port);
+    TEST_ASSERT_EQUAL_INT(23, (int)strlen(cfg.node_public_url));
+    TEST_ASSERT_EQUAL_INT(26, (int)strlen(cfg.validator_url));
+    TEST_ASSERT_EQUAL_INT(11, (int)strlen(cfg.pem_file));
+    TEST_ASSERT_EQUAL_CHAR_ARRAY("http://client-node:8080", cfg.node_public_url, 23);
+    TEST_ASSERT_EQUAL_CHAR_ARRAY("http://validator-node:8000", cfg.validator_url, 26);
+    TEST_ASSERT_EQUAL_CHAR_ARRAY("ed25519.pem", cfg.pem_file, 11);
 }
 
 int main(void)
@@ -342,6 +355,7 @@ int main(void)
     RUN_TEST(test_signer_verify_signature_failure_wrong_pub_key);
     RUN_TEST(test_signer_verify_signature_failure_corrupted_msg);
     RUN_TEST(test_signer_verify_signature_failure_corrupted_digest);
+    RUN_TEST(test_read_config);
 
     return UnityEnd();
 }

--- a/header.md
+++ b/header.md
@@ -295,7 +295,28 @@ The `gcc` compiler used for the test and development is `gcc version 9.4.0`.
 1. Install dependencies:
 
 - Install build essentials.
+
+```sh
+sudo apt install build-essential
+```
+
 - Install openssl library.
+
+```sh
+sudo apt install openssl
+```
+
+- Install autoconf
+
+```sh
+sudo apt-get install autoconf
+```
+
+- Install libtool
+
+```sh
+sudo apt install libtool
+```
 
 #### Tests
 


### PR DESCRIPTION
C impl needs a config file reader to read the config before running the client.

This is a simple tex file as we are not implementing any other node than the client node and do not need a nested setup.