### PR TITLE
c/client-node: validate config token values

### DIFF
--- a/c/client-node/config/config.c
+++ b/c/client-node/config/config.c
@@ -49,10 +49,12 @@ unit_static bool is_valid_url(char *url)
 {
     regex_t re;
     // url_re matches http|https + :// + one or more non-white-space-characters + : + port number between 1 and 65535.
-    if (regcomp(&re, "^https?:\\/\\/\\S+:([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$", REG_EXTENDED) != 0) {
+    if (regcomp(&re, "^https?:\\/\\/\\S+:([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$", REG_EXTENDED) != 0)
+    {
         return false;
     }
-    if (regexec(&re, url, 0, NULL, 0) != 0) {
+    if (regexec(&re, url, 0, NULL, 0) != 0)
+    {
         return false;
     }
     return true;
@@ -72,7 +74,8 @@ static bool assign_to_config(Config *cfg, char *name, char *token)
     if (strcmp("port", name_trimed) == 0)
     {
         int port = atoi(token_trimed);
-        if (port < 1 || port > 65535) {
+        if (port < 1 || port > 65535)
+        {
             return false;
         }
         cfg->port = port;
@@ -81,7 +84,8 @@ static bool assign_to_config(Config *cfg, char *name, char *token)
     
     if (strcmp("node_public_url", name_trimed) == 0)
     {
-        if (!is_valid_url(token_trimed)) {
+        if (!is_valid_url(token_trimed))
+        {
             return false;
         }
         strncpy(cfg->node_public_url, token_trimed, len);
@@ -90,7 +94,8 @@ static bool assign_to_config(Config *cfg, char *name, char *token)
 
     if (strcmp("validator_url", name_trimed) == 0)
     {
-        if (!is_valid_url(token_trimed)) {
+        if (!is_valid_url(token_trimed))
+        {
             return false;
         }
         strncpy(cfg->validator_url, token_trimed, len);

--- a/c/client-node/makefile
+++ b/c/client-node/makefile
@@ -24,6 +24,9 @@ PACKAGES += ./signature/*.c
 PACKAGES += ./config/*.c
 PACKAGES += ./*.c
 
+# Used to test static functions.
+UTFLAGS = -DUNIT_TEST
+
 .PHONY: test
 test: tests.out
 	@./tests.out
@@ -41,5 +44,5 @@ clean:
 
 tests.out: ./*.c ./*.h
 	@echo Compiling $@
-	@$(CC) $(CFLAGS) $(TEST_PACKAGES) $(PACKAGES) -o tests.out $(LIBS)
+	@$(CC) $(CFLAGS) $(UTFLAGS) $(TEST_PACKAGES) $(PACKAGES) -o tests.out $(LIBS)
 

--- a/c/client-node/test_client.c
+++ b/c/client-node/test_client.c
@@ -7,6 +7,7 @@
 ///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ///
+
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -17,7 +18,7 @@
 #include "./address/address.h"
 #include "./signature/signature.h"
 #include "./config/config.h"
-
+#include "unit-test.h"
 
 void setUp(void)
 {
@@ -340,6 +341,26 @@ static void test_read_config()
     TEST_ASSERT_EQUAL_CHAR_ARRAY("ed25519.pem", cfg.pem_file, 11);
 }
 
+static void test_handle_erroneous_config()
+{
+    // A valid url.
+    TEST_ASSERT_TRUE(is_valid_url("http://central-node:65535"));
+    // Invalid urls.
+    const char* invalid_urls[] = {
+        "ftp://central-node:8080",
+        "http:/central-node:8080",
+        "http:central-node:8080",
+        "http//central-node:8080",
+        "http://:8080",
+        "http://central-node:",
+        "http://central-node8080",
+        "http://central-node:0",
+        "http://central-node:65536"};
+    for (size_t i = 0; i < (sizeof(invalid_urls)/sizeof(char *)); i++) {
+        TEST_ASSERT_FALSE(is_valid_url((char*)invalid_urls[i]));
+    }
+}
+
 int main(void)
 {
     UnityBegin("test_client.c");
@@ -356,6 +377,7 @@ int main(void)
     RUN_TEST(test_signer_verify_signature_failure_corrupted_msg);
     RUN_TEST(test_signer_verify_signature_failure_corrupted_digest);
     RUN_TEST(test_read_config);
+    RUN_TEST(test_handle_erroneous_config);
 
     return UnityEnd();
 }

--- a/c/client-node/unit-test.h
+++ b/c/client-node/unit-test.h
@@ -2,36 +2,25 @@
 /// Copyright (C) 2023 by Computantis
 ///
 /// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without l> imitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 ///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ///
 
-#ifndef CONFIG_H
-#define CONFIG_H
-#define MAX_STRING 8192
+// Allow for unit testing static functions.
+//
+// Add -DUNIT_TEST to compilation and include this header in files that have static
+// functions that you'd like to test.  Mark those functions as unit_static and include
+// their signatures in an appropriate header file within a #if UNIT_TEST directive.
+// See config/config.h and config/config.c for an example.
+#ifndef UNIT_TEST_H
+#define UNIT_TEST_H
 
-/// 
-/// Config represents configuration required for the client node to run.
-///
-typedef struct {
-    int port;
-    char node_public_url[MAX_STRING];
-    char validator_url[MAX_STRING];
-    char pem_file[MAX_STRING];
-} Config;
-
-/// 
-/// Config_new_from_file reads Config from provided file path.
-///
-Config Config_new_from_file(char *file_path);
-
-///
-/// Expose static functions when unit testing.
-///
 #if UNIT_TEST
-bool is_valid_url(char *);
+#define unit_static
+#else
+#define unit_static static
 #endif
 
 #endif


### PR DESCRIPTION
Provides some basic port number and URL syntax validation.
Allows unit testing static functions (although @bartossh, you might have a better way to do this).