### PR TITLE
Free regex_t.

### DIFF
--- a/c/client-node/config/config.c
+++ b/c/client-node/config/config.c
@@ -51,12 +51,15 @@ unit_static bool is_valid_url(char *url)
     // url_re matches http|https + :// + one or more non-white-space-characters + : + port number between 1 and 65535.
     if (regcomp(&re, "^https?:\\/\\/\\S+:([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$", REG_EXTENDED) != 0)
     {
+        regfree(&re);
         return false;
     }
     if (regexec(&re, url, 0, NULL, 0) != 0)
     {
+        regfree(&re);
         return false;
     }
+        regfree(&re);
     return true;
 }
 

--- a/c/client-node/makefile
+++ b/c/client-node/makefile
@@ -34,7 +34,7 @@ test: tests.out
 .PHONY: memcheck
 memcheck: ./*.c ./*.h
 	@echo Compiling $@
-	@$(CC) $(ASANFLAGS) $(CFLAGS) $(TEST_PACKAGES) $(PACKAGES) -o memcheck.out $(LIBS)
+	@$(CC) $(ASANFLAGS) $(CFLAGS) $(UTFLAGS) $(TEST_PACKAGES) $(PACKAGES) -o memcheck.out $(LIBS)
 	@./memcheck.out
 	@echo "Memory check passed"
 


### PR DESCRIPTION
@kmroz sorry I missed that part when reviewing PR, as I am not a regex guy 🤓. It looks like we have to free the memory of the regex after using it.
Because it is used only when checking a config I will not move it into the separate method (function on the first param being some structure holding the pointer to regex_t). It is unnecessary. Instead, I clean it after using it. Simple.

- There is a command provided in the makefile allowing to check memory sanitization:
```sh
make memcheck
```

The above will do the trick and print all allocations that are not freed.