### PR TITLE
222 separate repository functionalities

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -26,44 +26,50 @@ type BlockWriter interface {
 	WriteBlock(ctx context.Context, block block.Block) error
 }
 
-// BlockReadWriter provides read and write access to the blockchain repository.
-type BlockReadWriter interface {
+// BlockFinder provides functionality to look for block containing certain transaction.
+type BlockFinder interface {
+	FindTransactionInBlockHash(ctx context.Context, trxHash [32]byte) ([32]byte, error)
+}
+
+// BlockReadWriteFinder provides read and write access to the blockchain repository.
+type BlockReadWriteFinder interface {
 	BlockReader
 	BlockWriter
+	BlockFinder
 }
 
 // Blockchain keeps track of the blocks creating immutable chain of data.
 // Blockchain is stored in repository as separate blocks that relates to each other
 // based on the hash of the previous block.
 type Blockchain struct {
-	rw BlockReadWriter
+	rwf BlockReadWriteFinder
 }
 
 // GenesisBlock creates a genesis block. It is a first block in the blockchain.
 // The genesis block is created only if there is no other block in the repository.
-// Otherwise returning an error.
-func GenesisBlock(ctx context.Context, rw BlockReadWriter) error {
-	if b, err := rw.LastBlock(ctx); err == nil && b.Index != 0 {
+// Otherwfise returning an error.
+func GenesisBlock(ctx context.Context, rwf BlockReadWriteFinder) error {
+	if b, err := rwf.LastBlock(ctx); err == nil && b.Index != 0 {
 		return errors.New("genesis block already exists")
 	}
 	h := sha256.Sum256([]byte("genesis block"))
 	b := block.New(0, 1, h, [][32]byte{})
-	return rw.WriteBlock(ctx, b)
+	return rwf.WriteBlock(ctx, b)
 }
 
 // New creates a new Blockchain that has access to the blockchain stored in the repository.
-// The access to the repository is injected via BlockReadWriter interface.
-// You can use any implementation of repository that implements BlockReadWriter interface
+// The access to the repository is injected via BlockReadWriteFinder interface.
+// You can use any implementation of repository that implements BlockReadWriteFinder interface
 // and ensures unique indexing for Block Hash, PrevHash and Index.
-func New(ctx context.Context, rw BlockReadWriter) (*Blockchain, error) {
+func New(ctx context.Context, rwf BlockReadWriteFinder) (*Blockchain, error) {
 	return &Blockchain{
-		rw: rw,
+		rwf: rwf,
 	}, nil
 }
 
 // LastBlockHashIndex returns last block hash and index.
 func (c *Blockchain) LastBlockHashIndex(ctx context.Context) ([32]byte, uint64, error) {
-	lastBlock, err := c.rw.LastBlock(ctx)
+	lastBlock, err := c.rwf.LastBlock(ctx)
 	if err != nil {
 		return [32]byte{}, 0, err
 	}
@@ -72,7 +78,7 @@ func (c *Blockchain) LastBlockHashIndex(ctx context.Context) ([32]byte, uint64, 
 
 // ReadLastNBlocks reads the last n blocks in reverse consecutive order.
 func (c *Blockchain) ReadLastNBlocks(ctx context.Context, n int) ([]block.Block, error) {
-	lastBlock, err := c.rw.LastBlock(ctx)
+	lastBlock, err := c.rwf.LastBlock(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +86,7 @@ func (c *Blockchain) ReadLastNBlocks(ctx context.Context, n int) ([]block.Block,
 	blocks := make([]block.Block, 0, n)
 	lastBlockHash := lastBlock.Hash
 	for n > 0 {
-		block, err := c.rw.ReadBlockByHash(ctx, lastBlockHash)
+		block, err := c.rwf.ReadBlockByHash(ctx, lastBlockHash)
 		if err != nil {
 			return nil, err
 		}
@@ -94,7 +100,7 @@ func (c *Blockchain) ReadLastNBlocks(ctx context.Context, n int) ([]block.Block,
 
 // ReadBlocksFromIndex reads all blocks from given index till the current block in consecutive order.
 func (c *Blockchain) ReadBlocksFromIndex(ctx context.Context, idx uint64) ([]block.Block, error) {
-	lastBlock, err := c.rw.LastBlock(ctx)
+	lastBlock, err := c.rwf.LastBlock(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +108,7 @@ func (c *Blockchain) ReadBlocksFromIndex(ctx context.Context, idx uint64) ([]blo
 	blocks := make([]block.Block, 0, lastBlock.Index-idx)
 	lastBlockHash := lastBlock.Hash
 	for {
-		block, err := c.rw.ReadBlockByHash(ctx, lastBlockHash)
+		block, err := c.rwf.ReadBlockByHash(ctx, lastBlockHash)
 		if err != nil {
 			return nil, err
 		}
@@ -120,7 +126,7 @@ func (c *Blockchain) ReadBlocksFromIndex(ctx context.Context, idx uint64) ([]blo
 
 // WriteBlock writes block in to the blockchain repository.
 func (c *Blockchain) WriteBlock(ctx context.Context, block block.Block) error {
-	lastBlock, err := c.rw.LastBlock(ctx)
+	lastBlock, err := c.rwf.LastBlock(ctx)
 	if err != nil {
 		return err
 	}
@@ -133,9 +139,14 @@ func (c *Blockchain) WriteBlock(ctx context.Context, block block.Block) error {
 		return ErrInvalidBlockPrevHash
 	}
 
-	if err := c.rw.WriteBlock(ctx, block); err != nil {
+	if err := c.rwf.WriteBlock(ctx, block); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// FindTransactionInBlockHash looks for blockchain that contains transaction and returns its hash.
+func (c *Blockchain) FindTransactionInBlockHash(ctx context.Context, trxHash [32]byte) ([32]byte, error) {
+	return c.rwf.FindTransactionInBlockHash(ctx, trxHash)
 }

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/bartossh/Computantis/fileoperations"
 	"github.com/bartossh/Computantis/logging"
 	"github.com/bartossh/Computantis/logo"
-	"github.com/bartossh/Computantis/repository"
 	"github.com/bartossh/Computantis/stdoutwriter"
 	"github.com/bartossh/Computantis/telemetry"
 	"github.com/bartossh/Computantis/wallet"
@@ -83,16 +82,6 @@ func run(cfg configuration.Configuration) {
 		cancel()
 	}()
 
-	db, err := repository.Connect(ctx, cfg.Database)
-	if err != nil {
-		fmt.Println(err)
-		c <- os.Interrupt
-		return
-	}
-	ctxx, cancelClose := context.WithTimeout(context.Background(), time.Second*1)
-	defer cancelClose()
-	defer db.Disconnect(ctxx)
-
 	callbackOnErr := func(err error) {
 		fmt.Println("error with logger: ", err)
 	}
@@ -108,7 +97,7 @@ func run(cfg configuration.Configuration) {
 		return
 	}
 
-	log := logging.New(callbackOnErr, callbackOnFatal, db, stdoutwriter.Logger{}, &zinc)
+	log := logging.New(callbackOnErr, callbackOnFatal, stdoutwriter.Logger{}, &zinc)
 
 	seal := aeswrapper.New()
 	fo := fileoperations.New(cfg.FileOperator, seal)

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -20,15 +20,24 @@ import (
 // Configuration is the main configuration of the application that corresponds to the *.yaml file
 // that holds the configuration.
 type Configuration struct {
-	Server       server.Config         `yaml:"server"`
-	Database     repository.DBConfig   `yaml:"database"`
-	Client       walletapi.Config      `yaml:"client"`
-	FileOperator fileoperations.Config `yaml:"file_operator"`
-	ZincLogger   zincaddapter.Config   `yaml:"zinc_logger"`
-	Validator    validator.Config      `yaml:"validator"`
-	Emulator     emulator.Config       `yaml:"emulator"`
-	DataProvider dataprovider.Config   `yaml:"data_provider"`
-	Bookkeeper   bookkeeping.Config    `yaml:"bookkeeper"`
+	Server        server.Config         `yaml:"server"`
+	StorageConfig StorageConfig         `yaml:"storage_config"`
+	Client        walletapi.Config      `yaml:"client"`
+	FileOperator  fileoperations.Config `yaml:"file_operator"`
+	ZincLogger    zincaddapter.Config   `yaml:"zinc_logger"`
+	Validator     validator.Config      `yaml:"validator"`
+	Emulator      emulator.Config       `yaml:"emulator"`
+	DataProvider  dataprovider.Config   `yaml:"data_provider"`
+	Bookkeeper    bookkeeping.Config    `yaml:"bookkeeper"`
+}
+
+type StorageConfig struct {
+	TransactionDatabase     repository.DBConfig `yaml:"transaction_database"`
+	BlockchainDatabase      repository.DBConfig `yaml:"blockchain_database"`
+	NodeRegisterDatabase    repository.DBConfig `yaml:"node_register_database"`
+	AddressDatabase         repository.DBConfig `yaml:"address_database"`
+	TokenDatabase           repository.DBConfig `yaml:"token_database"`
+	ValidatorStatusDatabase repository.DBConfig `yaml:"validator_status_database"`
 }
 
 // Read reads the configuration from the file and returns the Configuration with set fields according to the yaml setup.

--- a/header.md
+++ b/header.md
@@ -114,10 +114,31 @@ server:
   port: 8080 # Port on which the central node REST API is exposed.
   data_size_bytes: 15000000 # Size of bytes allowed in a single transaction, all above that will be rejected.
   websocket_address: "ws://localhost:8080/ws" # This is the external address of the central node needed to register for other central nodes to use to inform validators.
-database:
-  conn_str: "postgres://computantis:computantis@localhost:5432" # Database connection string. For now only PostgreSQL is supported.
-  database_name: "computantis" # Database name to store all the computantis related data.
-  is_ssl: false # Set to true if database requires SSL or to false otherwise, On production SSL true is a must. 
+storage_config: # Collection of settings for dedicated repositories for entities.
+  transaction_database:
+    conn_str: "postgres://computantis:computantis@postgres:5432"  # Database connection string. For now only PostgreSQL is supported.
+    database_name: "computantis" # Database name to store all the computantis related data.
+    is_ssl: false # Set to true if database requires SSL or to false otherwise, On production SSL true is a must. 
+  blockchain_database:
+    conn_str: "postgres://computantis:computantis@postgres:5432" # Database connection string. For now only PostgreSQL is supported.
+    database_name: "computantis" # Database name to store all the computantis related data.
+    is_ssl: false # Set to true if database requires SSL or to false otherwise, On production SSL true is a must. 
+  node_register_database:
+    conn_str: "postgres://computantis:computantis@postgres:5432" # Database connection string. For now only PostgreSQL is supported.
+    database_name: "computantis" # Database name to store all the computantis related data.
+    is_ssl: false # Set to true if database requires SSL or to false otherwise, On production SSL true is a must. 
+  address_database:
+    conn_str: "postgres://computantis:computantis@postgres:5432" # Database connection string. For now only PostgreSQL is supported.
+    database_name: "computantis" # Database name to store all the computantis related data.
+    is_ssl: false # Set to true if database requires SSL or to false otherwise, On production SSL true is a must. 
+  token_database:
+    conn_str: "postgres://computantis:computantis@postgres:5432" # Database connection string. For now only PostgreSQL is supported.
+    database_name: "computantis" # Database name to store all the computantis related data.
+    is_ssl: false # Set to true if database requires SSL or to false otherwise, On production SSL true is a must. 
+  validator_status_database:
+    conn_str: "postgres://computantis:computantis@postgres:5432" # Database connection string. For now only PostgreSQL is supported.
+    database_name: "computantis" # Database name to store all the computantis related data.
+    is_ssl: false # Set to true if database requires SSL or to false otherwise, On production SSL true is a must.
 dataprovider:
   longevity: 300 # Data provider provides the data to be signed by the wallet holder in order to verify the wallet public key. This is a time [ s ] describing how long data are valid.
 zinc_logger: # Zinc search (elastic-search like service) for convenient access to logs. 

--- a/setup_example.yaml
+++ b/setup_example.yaml
@@ -6,10 +6,31 @@ server:
   port: 8000
   data_size_bytes: 15000000
   websocket_address: "ws://central-node:8000/ws"
-database:
-  conn_str: "postgres://computantis:computantis@postgres:5432"
-  database_name: "computantis"
-  is_ssl: false
+storage_config:
+  transaction_database:
+    conn_str: "postgres://computantis:computantis@postgres:5432"
+    database_name: "computantis"
+    is_ssl: false
+  blockchain_database:
+    conn_str: "postgres://computantis:computantis@postgres:5432"
+    database_name: "computantis"
+    is_ssl: false
+  node_register_database:
+    conn_str: "postgres://computantis:computantis@postgres:5432"
+    database_name: "computantis"
+    is_ssl: false
+  address_database:
+    conn_str: "postgres://computantis:computantis@postgres:5432"
+    database_name: "computantis"
+    is_ssl: false
+  token_database:
+    conn_str: "postgres://computantis:computantis@postgres:5432"
+    database_name: "computantis"
+    is_ssl: false
+  validator_status_database:
+    conn_str: "postgres://computantis:computantis@postgres:5432"
+    database_name: "computantis"
+    is_ssl: false
 dataprovider:
   longevity: 300
 validator:


### PR DESCRIPTION
While data repository, synchronization, data redundancy and some communication functionalities are separated by a facade interface, all of them are offered by a single PostgreSQL database. This creates a bottleneck. 
To keep the same technical solution and code for managing all the external dependencies and data read/writes we can simply separate the providers by injecting the dependencies that offer separated functionality and arrive from different services.
Therefore we will have many separate smaller databases offering a smaller portion of functionality and being able to maintain higher throughput.

We will separate the db keeping those parts together:
- addresses, that is the participants allowed to connect as nodes and create transactions:
    - addresses          
    - addresses_id_seq   
- blockchain, that is all repository functions on blocks:
    - blockchainlocks    
    - blockchainlocks_id_seq 
    - blocks 
    - blocks_id_seq
- logs (shall be removed soon as we are using zincserch in place)
    - logs 
    - logs_id_seq
- nodes and validator statuses registered in the system
    - nodes
    - nodes_id_seq 
    - validatorstatus 
    - validatorstatus_id_seq 
- tokens for validators and other computantis nodes or yet unregistered wallets
    - tokens
    - tokens_id_seq
- transactions, all functions of the repository on the transactions (the heavily loaded with queries, here the best server needs to be dedicated.)
    - transactions 
    - transactions_id_seq

