### PR TITLE
Remove unnecessary tags.

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -18,8 +18,8 @@ const (
 
 // Wallet holds public and private key of the wallet owner.
 type Wallet struct {
-	Private ed25519.PrivateKey `json:"private" bson:"private"` // TODO: Make ephemaral structure with public filelds for json, bson encoding and make this fields private.
-	Public  ed25519.PublicKey  `json:"public" bson:"public"`
+	Private ed25519.PrivateKey
+	Public  ed25519.PublicKey
 }
 
 // New tries to creates a new Wallet or returns error otherwise.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -18,8 +18,8 @@ const (
 
 // Wallet holds public and private key of the wallet owner.
 type Wallet struct {
-	Private ed25519.PrivateKey
-	Public  ed25519.PublicKey
+	Private ed25519.PrivateKey `gob:"private"`
+	Public  ed25519.PublicKey  `gob:"public"`
 }
 
 // New tries to creates a new Wallet or returns error otherwise.


### PR DESCRIPTION
Wallet fields are used in gob encoding. Fields are required to be public to allow the encoder to set them. I've added the gob tags for the encoder. 