### PR TITLE
230 test wallet was removed

### DIFF
--- a/cmd/wallet/main.go
+++ b/cmd/wallet/main.go
@@ -161,6 +161,8 @@ func run(action int, cfg fileoperations.Config) error {
 		if err := h.SaveToPem(&w); err != nil {
 			return err
 		}
+
+		pterm.Info.Printf("Wallet public address is [ %s ]\n", w.Address())
 		return nil
 	case actionFromGobToPem:
 		h := fileoperations.New(cfg, aeswrapper.New())
@@ -171,6 +173,7 @@ func run(action int, cfg fileoperations.Config) error {
 		if err := h.SaveToPem(&w); err != nil {
 			return err
 		}
+		pterm.Info.Printf("Wallet public address is [ %s ]\n", w.Address())
 		return nil
 
 	case actionFromPemToGob:
@@ -182,6 +185,7 @@ func run(action int, cfg fileoperations.Config) error {
 		if err := h.SaveWallet(&w); err != nil {
 			return err
 		}
+		pterm.Info.Printf("Wallet public address is [ %s ]\n", w.Address())
 		return nil
 	default:
 		return errors.New("unimplemented action")

--- a/cmd/wallet/main.go
+++ b/cmd/wallet/main.go
@@ -161,8 +161,7 @@ func run(action int, cfg fileoperations.Config) error {
 		if err := h.SaveToPem(&w); err != nil {
 			return err
 		}
-
-		pterm.Info.Printf("Wallet public address is [ %s ]\n", w.Address())
+		printWalletPublicAddress(w.Address())
 		return nil
 	case actionFromGobToPem:
 		h := fileoperations.New(cfg, aeswrapper.New())
@@ -173,7 +172,7 @@ func run(action int, cfg fileoperations.Config) error {
 		if err := h.SaveToPem(&w); err != nil {
 			return err
 		}
-		pterm.Info.Printf("Wallet public address is [ %s ]\n", w.Address())
+		printWalletPublicAddress(w.Address())
 		return nil
 
 	case actionFromPemToGob:
@@ -185,12 +184,16 @@ func run(action int, cfg fileoperations.Config) error {
 		if err := h.SaveWallet(&w); err != nil {
 			return err
 		}
-		pterm.Info.Printf("Wallet public address is [ %s ]\n", w.Address())
+		printWalletPublicAddress(w.Address())
 		return nil
 	default:
 		return errors.New("unimplemented action")
 
 	}
+}
+
+func printWalletPublicAddress(address string) {
+	pterm.Info.Printf("Wallet public address is [ %s ]\n", address)
 }
 
 func printSuccess() {

--- a/docker_postgres_init.sql
+++ b/docker_postgres_init.sql
@@ -165,4 +165,4 @@ INSERT INTO tokens (token, valid, expiration_date) VALUES ('e3b0c44298fc1c149afb
 INSERT INTO tokens (token, valid, expiration_date) VALUES ('7147a8f255f49cb7693dcd19b6b46e139680d48a03e0a075ea237deb7e6bac11', true, 9223372036854775807);
 INSERT INTO tokens (token, valid, expiration_date) VALUES ('11b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b543', true, 9223372036854775807);
 
-INSERT INTO addresses (public_key, access_level) VALUES ('1AGb92ohiRtHFzrsVbMswxwARe5KeLBYkUzVgq9fTgUsAnmpyh', 'trusted');
+INSERT INTO addresses (public_key, access_level) VALUES ('1QtxpcaQbZg7qhdZr7EUoeQVr585s8sD3UCyZMXJSKawUpM5ze', 'trusted');

--- a/test_wallet
+++ b/test_wallet
@@ -1,0 +1,2 @@
+­ ¶Èº´‚Àjp“¸è£–]ÿÝ¼VJ½Š¿B¿É#‡¿Ç©^ôæ-Q€$6€^^²Gyjõ¾eq|!)„‚LCvÈløP…z´…QÏn·Í=ZWd6úûîáÑá=‰))»/V<“[’h}6”	DHV¯ãiùðpì†¶­BzÏÀ«ô*ÔÛ‚ÌdÓ»–ùÁ
+Õ¤-<Gß‘æÆµÁŠûbòÐI˜ÿfÄ&éêûR¼Œ"F^


### PR DESCRIPTION
At some point in the development process, I was wrongly thinking that test_wallet is not needed. But for tests on development, we need that wallet as there is a query running in the migration docker_postgres_init.sql that adds the wallet public address as the trusted so the validator using that wallet can connect to the system.
There is a need to get the wallet back and update the query.